### PR TITLE
Correct number of REWE stores in Germany

### DIFF
--- a/data/compare.json
+++ b/data/compare.json
@@ -505,7 +505,7 @@
   {
     "id": "5b0731306e515667e43a1bff6d2ae879f80da3791d96eef8abb59f6c30304876",
     "name": "REWE",
-    "expected": 47200,
+    "expected": 3749,
     "actual": 3637,
     "expectedSource": "https://www.rewe-group.com/content/uploads/2023/06/rewe-group-financial-report-2022.pdf?t=2023092210",
     "actualSource": "taginfo",


### PR DESCRIPTION
The expected number of REWE stores in Germany cites the _Financial Report 2022, REWE-ZENTRALFINANZ eG_.

In this, the table titled `Locations as at 31 December 2022` notes 3733 german retail locations and 16 convenience locations, totalling 3749 locations.